### PR TITLE
Fix hash map printing

### DIFF
--- a/parseedn.el
+++ b/parseedn.el
@@ -141,16 +141,16 @@ TAG-READERS is an optional association list.  For more information, see
       (insert " ")
       (parseedn-print-seq next))))
 
-(defun parseedn-print-kvs (map)
+(defun parseedn-print-kvs (map &optional ks)
   "Insert hash table MAP as an EDN map into the current buffer."
-  (let ((keys (a-keys map)))
+  (let ((keys (or ks (a-keys map))))
     (parseedn-print (car keys))
     (insert " ")
     (parseedn-print (a-get map (car keys)))
     (let ((next (cdr keys)))
       (when (not (seq-empty-p next))
         (insert ", ")
-        (parseedn-print-kvs next)))))
+        (parseedn-print-kvs map next)))))
 
 (defun parseedn-print (datum)
   "Insert DATUM as EDN into the current buffer.

--- a/test/parseedn-test.el
+++ b/test/parseedn-test.el
@@ -37,7 +37,19 @@
   (should (equal (parseedn-print-str 100) "100"))
   (should (equal (parseedn-print-str 1.2) "1.2"))
   (should (equal (parseedn-print-str [1 2 3]) "[1 2 3]"))
-  (should (equal (parseedn-print-str t) "true")))
+  (should (equal (parseedn-print-str t) "true"))
+  (should (listp (member (parseedn-print-str
+                          (let ((ht (make-hash-table)))
+                            (puthash :a 1 ht)
+                            (puthash :b 2 ht)
+                            (puthash :c 3 ht)
+                            ht))
+                         '("{:a 1, :b 2, :c 3}"
+                           "{:a 1, :c 3, :b 2}"
+                           "{:b 2, :a 1, :c 3}"
+                           "{:b 2, :c 3, :a 1}"
+                           "{:c 3, :a 1, :b 2}"
+                           "{:c 3, :b 2, :a 1}")))))
 
 (ert-deftest parseedn-read-test ()
   (should (equal (parseedn-read-str "true") t)))


### PR DESCRIPTION
Hi,

the printing of hash-maps only seems to work for maps containing a single (or zero) entries:

```elisp
(parseedn-print-str 
 (let ((ht (make-hash-table)))
   (puthash :a 1 ht)
   (puthash :b 2 ht)
   (puthash :c 3 ht)
   ht))
```

```
Debugger entered--Lisp error: (wrong-type-argument listp :b)
  car(:b)
  mapcar(car (:b :c))
  a-keys((:b :c))
  (let ((keys (a-keys map))) (parseedn-print (car keys)) (insert " ") (parseedn-print (a-get map (car keys))) (let ((next (cdr keys))) (if (not (seq-empty-p next)) (progn (insert ", ") (parseedn-print-kvs next)))))
  parseedn-print-kvs((:b :c))
  (progn (insert ", ") (parseedn-print-kvs next))
  (if (not (seq-empty-p next)) (progn (insert ", ") (parseedn-print-kvs next)))
  (let ((next (cdr keys))) (if (not (seq-empty-p next)) (progn (insert ", ") (parseedn-print-kvs next))))
  (let ((keys (a-keys map))) (parseedn-print (car keys)) (insert " ") (parseedn-print (a-get map (car keys))) (let ((next (cdr keys))) (if (not (seq-empty-p next)) (progn (insert ", ") (parseedn-print-kvs next)))))
  parseedn-print-kvs(#<hash-table eql 3/65 0x2d1d8ad>)
```

I've added a fix and a test for this, please let me know if I've missed anything. Thanks!