### PR TITLE
Add support for alist, plist and an explicit error for dotted pairs

### DIFF
--- a/test/parseedn-test.el
+++ b/test/parseedn-test.el
@@ -39,7 +39,7 @@
   (should (equal (parseedn-print-str [1 2 3]) "[1 2 3]"))
   (should (equal (parseedn-print-str t) "true"))
   (should (equal (parseedn-print-str '((a . 1) (b . 2))) "{a 1, b 2}"))
-  (should (equal (parseedn-print-str '((a . 1) (b . ((c . 3))))) "{:a 1, :b {:c 3}}"))
+  (should (equal (parseedn-print-str '((a . 1) (b . ((c . 3))))) "{a 1, b {c 3}}"))
   (should (equal (parseedn-print-str '(:a 1 :b 2)) "{:a 1, :b 2}"))
   (should (equal (parseedn-print-str '(:a 1 :b (:c 3))) "{:a 1, :b {:c 3}}"))
   (should (listp (member (parseedn-print-str

--- a/test/parseedn-test.el
+++ b/test/parseedn-test.el
@@ -38,6 +38,10 @@
   (should (equal (parseedn-print-str 1.2) "1.2"))
   (should (equal (parseedn-print-str [1 2 3]) "[1 2 3]"))
   (should (equal (parseedn-print-str t) "true"))
+  (should (equal (parseedn-print-str '((a . 1) (b . 2))) "{a 1, b 2}"))
+  (should (equal (parseedn-print-str '((a . 1) (b . ((c . 3))))) "{:a 1, :b {:c 3}}"))
+  (should (equal (parseedn-print-str '(:a 1 :b 2)) "{:a 1, :b 2}"))
+  (should (equal (parseedn-print-str '(:a 1 :b (:c 3))) "{:a 1, :b {:c 3}}"))
   (should (listp (member (parseedn-print-str
                           (let ((ht (make-hash-table)))
                             (puthash :a 1 ht)


### PR DESCRIPTION
I tried to replicate the heuristics in `json-encode`, which converts the dotted pairs found in `alist`s and the lists that it guesses are `plist`s into reasonable JSON.

In addition, I added support for `keyword`s and an `error` call when the parser encounters anything it doesn't know how to emit to make future debugging a bit easier.

Lastly, there's a line with a comment saying `dotted pair` to mark where one could add some sort of support for this as discussed in ticket #3. (N.B. that `json-encode` simply fails when fed a dotted pair that's not part of an `alist`.)

This patch allows JSON -> elisp -> EDN -> elisp -> JSON round tripping, in case that ever comes up. 😹