### PR TITLE
Add print handler for #uuid and #inst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Added print handler for `#uuid` and `#inst`
+
 ## Fixed
 
 ## Changed

--- a/parseedn.el
+++ b/parseedn.el
@@ -162,6 +162,13 @@ TAG-READERS is an optional association list.  For more information, see
       (insert ", ")
       (parseedn-print-plist next))))
 
+(defun parseedn-print-inst (time)
+  "Insert an inst value into the current buffer.
+
+Take an encode-time style value and print it as a timestamp
+deliniated by double quotes."
+  (insert (format-time-string "\"%Y-%m-%dT%T\"" time)))
+
 (defun parseedn-alist-p (list)
   "Non-null if and only if LIST is an alist with simple keys."
   (while (consp list)
@@ -224,6 +231,10 @@ DATUM can be any Emacs Lisp value."
       (error "Don't know how to print: %s" datum))
      ((eq 'edn-set (car datum))
       (insert "#{") (parseedn-print-seq (cadr datum)) (insert "}"))
+     ((eq 'edn-uuid (car datum))
+      (insert "#uuid ") (parseedn-print-seq (cdr datum)))
+     ((eq 'edn-inst (car datum))
+      (insert "#inst ") (parseedn-print-inst (cdr datum)))
      (t (insert "(") (parseedn-print-seq datum) (insert ")"))))
 
    (t (error "Don't know how to print: %s" datum))))

--- a/test/parseedn-test-data.el
+++ b/test/parseedn-test-data.el
@@ -340,6 +340,16 @@
        "booleans"
        (a-list
         :source "[nil true false]"
-        :edn '([nil t nil]))))
+        :edn '([nil t nil]))
+
+       "uuid"
+       (a-list
+        :source "#uuid \"c9c4eac2-7b23-4d62-a444-41a72dc09039\""
+        :edn '((edn-uuid "c9c4eac2-7b23-4d62-a444-41a72dc09039")))
+
+       "inst"
+       (a-list
+        :source "#inst \"2020-09-09T06:56:04\""
+        :edn '((edn-inst 24408 24676 )))))
 
 ;;; parseedn-test-data.el ends here

--- a/test/parseedn-test-data.el
+++ b/test/parseedn-test-data.el
@@ -350,6 +350,7 @@
        "inst"
        (a-list
         :source "#inst \"2020-09-09T06:56:04\""
-        :edn '((edn-inst 24408 24676 )))))
+        ;; FIXME this value may differ depending on the timezone of your machine
+        :edn '((edn-inst 24408 31876)))))
 
 ;;; parseedn-test-data.el ends here


### PR DESCRIPTION
Since we parse these we should also print these.

Printing inst up to the second and without timestamp, since that is the
resolution we get from Emacs' date-to-time.

Will open a separate issue for millisecond and time zone handling.