### PR TITLE
Default data reader function and tagged literals

### DIFF
--- a/test/parseedn-test-data.el
+++ b/test/parseedn-test-data.el
@@ -277,7 +277,10 @@
 
        "tag-1"
        (a-list
+        :tags '(:edn-roundtrip)
+        :tag-readers '((:default . parseedn-tagged-literal))
         :source "#foo/bar [1]"
+        :edn '((edn-tagged-literal foo/bar [1]))
         :ast '((:node-type . :root)
                (:position . 1)
                (:children . (((:node-type . :tag)
@@ -292,7 +295,10 @@
 
        "tag-2"
        (a-list
+        :tags '(:edn-roundtrip)
+        :tag-readers '((:default . parseedn-tagged-literal))
         :source "(fn #param :param-name 1)"
+        :edn '((fn (edn-tagged-literal param :param-name) 1))
         :ast '((:node-type . :root)
                (:position . 1)
                (:children . (((:node-type . :list)
@@ -315,6 +321,9 @@
 
        "nested-tags"
        (a-list
+        :tags '(:edn-roundtrip)
+        :tag-readers '((:default . parseedn-tagged-literal))
+        :edn (list (vector `(edn-tagged-literal lazy-error (edn-tagged-literal error ,(a-hash-table :cause "Divide by zero")))))
         :source "[#lazy-error #error {:cause \"Divide by zero\"}]"
         :ast '((:node-type . :root)
                (:position . 1)


### PR DESCRIPTION
Hello,

sometime it is not possible to know in advance which tagged readers
need to be registered when reading EDN data.

For example, I would like to read Splunk log lines that have been
produced by many different systems, and I do not know in advance which
data readers those system have defined.

However, it's still useful to read this data and maybe only use some
of the data, or pass the data on to other systems. Clojure 1.7 added
support for this via so called default data readers.

This PR implements a way to provide a default data reader function. It
is modeled after Clojure's implementation which is described here [1].

Would you like to support this and merge the PR?

Thanks, Roman.

[1] https://insideclojure.org/2018/06/21/tagged-literal/