### PR TITLE
Iterative parseedn-print-seq to avoid overflows

### DIFF
--- a/parseedn.el
+++ b/parseedn.el
@@ -156,12 +156,12 @@ TAG-READERS is an optional association list.  For more information, see
 
 (defun parseedn-print-seq (coll)
   "Insert sequence COLL as EDN into the current buffer."
-  (unless (seq-empty-p coll)
-    (parseedn-print (elt coll 0)))
-  (let ((next (seq-drop coll 1)))
-    (when (not (seq-empty-p next))
+  (when (not (seq-empty-p coll))
+    (while (not (seq-empty-p coll))
+      (parseedn-print (elt coll 0))
       (insert " ")
-      (parseedn-print-seq next))))
+      (setq coll (seq-drop coll 1)))
+    (delete-char -1)))
 
 (defun parseedn-print-hash-or-alist (map &optional ks)
   "Insert hash table MAP or elisp alist as an EDN map into the current buffer."

--- a/test/parseedn-test.el
+++ b/test/parseedn-test.el
@@ -37,6 +37,8 @@
   (should (equal (parseedn-print-str nil) "nil"))
   (should (equal (parseedn-print-str 100) "100"))
   (should (equal (parseedn-print-str 1.2) "1.2"))
+  (should (equal (parseedn-print-str []) "[]"))
+  (should (equal (parseedn-print-str '(edn-set ())) "#{}"))           
   (should (equal (parseedn-print-str [1 2 3]) "[1 2 3]"))
   (should (equal (parseedn-print-str t) "true"))
   (should (equal (parseedn-print-str '((a . 1) (b . 2))) "{a 1, b 2}"))


### PR DESCRIPTION
Avoid C stack overflows, `(error "Variable binding depth exceeds max-specpdl-size")` and `(error "Lisp nesting exceeds ‘max-lisp-eval-depth’")` when working with large sequences.