### PR TITLE
Fix empty hash

### DIFF
--- a/parseedn.el
+++ b/parseedn.el
@@ -165,7 +165,7 @@ TAG-READERS is an optional association list.  For more information, see
 
 (defun parseedn-print-hash-or-alist (map &optional ks)
   "Insert hash table MAP or elisp alist as an EDN map into the current buffer."
-  (let ((keys (or ks (map-keys map))))
+  (when-let ((keys (or ks (map-keys map))))
     (parseedn-print (car keys))
     (insert " ")
     (parseedn-print (map-elt map (car keys)))

--- a/test/parseedn-test.el
+++ b/test/parseedn-test.el
@@ -45,6 +45,7 @@
   (should (equal (parseedn-print-str '(:a 1 :b (:c 3))) "{:a 1, :b {:c 3}}"))
   (should (equal (parseedn-print-str '(edn-tagged-literal unknown "data")) "#unknown \"data\""))
   (should (equal (parseedn-print-str '(edn-tagged-literal unknown (edn-tagged-literal unknown "data"))) "#unknown #unknown \"data\""))
+  (should (equal (parseedn-print-str #s(hash-table size 0 data ())) "{}"))
   (should (listp (member (parseedn-print-str
                           (let ((ht (make-hash-table)))
                             (puthash :a 1 ht)


### PR DESCRIPTION
Before: `(parseedn-print-str #s(hash-table size 0 data ())) ;; =>  "{nil nil}"`
After:    `(parseedn-print-str #s(hash-table size 0 data ())) ;; => "{}"`
